### PR TITLE
Add Lithuanian language support

### DIFF
--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -6,15 +6,14 @@ import (
 	"github.com/sentencizer/sentencizer/internal/processor"
 )
 
-var (
-	langMap = map[string]*processor.Config{
-		"en": processor.Standard(),
-		"zh": newChinese(),
-		"ja": newJapanese(),
-		"ru": newRussian(),
-		"he": newHebrew(),
-	}
-)
+var langMap = map[string]*processor.Config{
+	"en": processor.Standard(),
+	"zh": newChinese(),
+	"ja": newJapanese(),
+	"ru": newRussian(),
+	"he": newHebrew(),
+	"lt": newLithuanian(),
+}
 
 func Lang(lang string) *processor.Config {
 	if _, ok := langMap[lang]; !ok {

--- a/internal/lang/lithuanian.go
+++ b/internal/lang/lithuanian.go
@@ -1,0 +1,320 @@
+package lang
+
+import (
+	"regexp"
+
+	"github.com/sentencizer/sentencizer/internal/processor"
+	"github.com/sentencizer/sentencizer/internal/replacer"
+	"github.com/sentencizer/sentencizer/internal/rule"
+)
+
+type DirectSpeechRules struct {
+	All rule.Rules
+}
+
+var (
+	questionExclamationMarkDirectSpeechRule = rule.NewRule(
+		regexp.MustCompile(`\?!(\s–\s[a-ž])`), `&ᓷ&&ᓴ&$1`,
+	)
+	exclamationMarkDirectSpeechRule = rule.NewRule(
+		regexp.MustCompile(`!(\s–\s[a-ž])`), `&ᓴ&$1`,
+	)
+	questionMarkDirectSpeechRule = rule.NewRule(
+		regexp.MustCompile(`\?(\s–\s[a-ž])`), `&ᓷ&$1`,
+	)
+	exclamationMarkTwoRule = rule.NewRule(
+		regexp.MustCompile(`!\.\.`), `&ᓴ&∯.`,
+	)
+	questionMarkTwoRule = rule.NewRule(
+		regexp.MustCompile(`\?\.\.`), `&ᓷ&∯.`,
+	)
+	// https://rubular.com/r/zrmWh8sRQ4R8Ay
+	horizontalEllipsisRule = rule.NewRule(
+		regexp.MustCompile(`…(\s+[A-Ž])`), `☍☍.$1`,
+	)
+	reinsertHorizontalEllipsis = rule.NewRule(
+		regexp.MustCompile(`☍☍.`), "…",
+	)
+
+	betweenLithuanianDoubleQuotesRegex = regexp.MustCompile(`„([^“\\]+|\\{2}|\\.)*“`)
+
+	directSpeechRules = DirectSpeechRules{
+		All: rule.Rules{
+			questionExclamationMarkDirectSpeechRule,
+			exclamationMarkDirectSpeechRule,
+			questionMarkDirectSpeechRule,
+		},
+	}
+)
+
+type betweenPunctuationReplacerLithuanian struct {
+	punctuationReplacer replacer.Punctuation
+	betweenPunctuation  replacer.BetweenPunctuation
+}
+
+func (b *betweenPunctuationReplacerLithuanian) subPunctuationBetweenLithuanianDoubleQuotes(text string) string {
+	return betweenLithuanianDoubleQuotesRegex.ReplaceAllStringFunc(
+		text,
+		b.punctuationReplacer.ReplaceFunc(processor.PunctuationMatchTypeNone),
+	)
+}
+
+func (b *betweenPunctuationReplacerLithuanian) subPunctuationInDirectSpeech(text string) string {
+	return directSpeechRules.All.Apply(text)
+}
+
+func (b *betweenPunctuationReplacerLithuanian) Replace(text string) string {
+	text = b.betweenPunctuation.Replace(text)
+	text = b.subPunctuationBetweenLithuanianDoubleQuotes(text)
+	text = b.subPunctuationInDirectSpeech(text)
+	return text
+}
+
+func newLithuanian() *processor.Config {
+	cfg := processor.Standard()
+	punctuationReplacer := replacer.NewPunctuationReplacer()
+	cfg.BetweenPunctuationReplacer = &betweenPunctuationReplacerLithuanian{
+		punctuationReplacer: punctuationReplacer,
+		betweenPunctuation:  replacer.NewBetweenPunctuation(punctuationReplacer),
+	}
+	// Based on https://www.vlkk.lt/aktualiausios-temos/rasyba/sutrumpinimai
+	cfg.Abbreviation.Abbreviations = []string{
+		"a. k",
+		"a. s",
+		"b. k",
+		"el. p",
+		"e. p",
+		"ir pan",
+		"ir t. t",
+		"J. E",  // Jo Ekscelencija
+		"J. Em", // Jo Eminencija
+		"k. a",  // kaip antai
+		"l. e. p",
+		"m. e", // mūsų eros
+		"m. m", // mokslo metai
+		"p. d",
+		"p. m. e", // prieš mūsų erą
+		"pr. Kr",
+		"pr. m. e",
+		"š. m",
+		"t. p",
+		"t. y",
+		"ž. ū",
+		"a",
+		"adm",
+		"adv",
+		"agr",
+		"akad",
+		"aklg",
+		"akt",
+		"al",
+		"angl",
+		"aps",
+		"apsk",
+		"apyg",
+		"apyl",
+		"art",
+		"asist",
+		"asmv",
+		"atsak",
+		"aut",
+		"avd", // asmenvardis
+		"biol",
+		"bkl",
+		"bot",
+		"bt",
+		"buh",
+		"buv",
+		"chem",
+		"d", // duktė; diena
+		"dail",
+		"dek",
+		"dėst",
+		"dir",
+		"dirig",
+		"doc",
+		"dr",
+		"drg",
+		"drp", // durpynas
+		"dš",
+		"egz",
+		"eil",
+		"ekon",
+		"e", // elektroninis
+		"el",
+		"etc",
+		"ež",
+		"fak",
+		"faks",
+		"filol",
+		"filos",
+		"g",
+		"gen",
+		"geol",
+		"gerb",
+		"gim", // gyvenvietė
+		"gv",
+		"gyd",
+		"įl",
+		"insp",
+		"inž",
+		"istor",
+		"k", // kaimas
+		"kand",
+		"kat",
+		"kl",
+		"kln",
+		"kn",
+		"koresp",
+		"kpt",
+		"kr",
+		"kt",
+		"kun",
+		"kyš",
+		"lent",
+		"ltn",
+		"m",
+		"mat",
+		"med",
+		"mėn",
+		"mgr",
+		"mjr",
+		"mln",
+		"mlrd",
+		"mok",
+		"mokyt",
+		"mot",
+		"mst",
+		"mstl",
+		"nkt", // nekaitomas
+		"ntk",
+		"nr",
+		"p", // ponas, ponia, panelė; puslapis; punktas
+		"pav",
+		"pavad",
+		"pėst",
+		"pil",
+		"pirm",
+		"pl",
+		"plg",
+		"plk",
+		"pr",
+		"pranc",
+		"prof",
+		"prok",
+		"prot", // protokolas
+		"psl",
+		"pss", // pusiasalis
+		"pšt",
+		"pvz",
+		"r", // rajonas
+		"raj",
+		"red",
+		"rež",
+		"rš",
+		"s", // sūnus, sąskaita
+		"sąs",
+		"sąsk",
+		"sav",
+		"saviv",
+		"sekr",
+		"sen",
+		"serž",
+		"sk",
+		"skg",
+		"skv",
+		"skyr",
+		"šnek",
+		"šv",
+		"sp",
+		"spec",
+		"sr", // sritis
+		"st",
+		"str",
+		"stud",
+		"t", // tomas
+		"techn",
+		"tel",
+		"teol",
+		"tir",
+		"tūkst",
+		"tšk",
+		"up",
+		"upl",
+		"vad",
+		"ved",
+		"vet",
+		"virš",
+		"vlsč",
+		"vnt",
+		"vs",
+		"vtv",
+		"vv",
+		"vyr",
+		"vyriaus",
+		"vyresn",
+		"žml",
+		"zool",
+		"žr",
+	}
+	cfg.Abbreviation.PrePositiveAbbreviations = []string{
+		"adm",
+		"adv",
+		"agr",
+		"akad",
+		"akt",
+		"art",
+		"asist",
+		"aut",
+		"buh",
+		"dail",
+		"dr",
+		"dek",
+		"dėst",
+		"dir",
+		"dirig",
+		"doc",
+		"drg",
+		"d",
+		"gen",
+		"gyd",
+		"insp",
+		"inž",
+		"kand",
+		"kpt",
+		"koresp",
+		"ltn",
+		"mjr",
+		"mok",
+		"mokyt",
+		"pav",
+		"pavad",
+		"pėst",
+		"pil",
+		"pirm",
+		"p",
+		"prof",
+		"prok",
+		"plk",
+		"red",
+		"rež",
+		"sekr",
+		"serž",
+		"stud",
+		"s",
+		"ved",
+	}
+	cfg.Abbreviation.NumberAbbreviations = []string{"Nr", "nr"}
+	cfg.SentenceStarters = nil
+	cfg.Ellipsis.All = append(
+		cfg.Ellipsis.All,
+		exclamationMarkTwoRule,
+		questionMarkTwoRule,
+		horizontalEllipsisRule,
+	)
+	cfg.ReinsertEllipsisRules.All = append(
+		cfg.ReinsertEllipsisRules.All,
+		reinsertHorizontalEllipsis,
+	)
+	return cfg
+}

--- a/internal/lang/lithuanian_test.go
+++ b/internal/lang/lithuanian_test.go
@@ -1,0 +1,93 @@
+package lang_test
+
+import (
+	"testing"
+
+	"github.com/sentencizer/sentencizer"
+)
+
+func Test_Lithuanian(t *testing.T) {
+	type args struct {
+		text string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "1) Direct speech ending with exclamation mark",
+			args: args{
+				text: "– Labas! – švelniai tarė.",
+			},
+			want: []string{"– Labas! – švelniai tarė."},
+		},
+		{
+			name: "2) Direct speech ending with question mark",
+			args: args{
+				text: "– Kaip laikaisi? – žvaliai paklausė.",
+			},
+			want: []string{"– Kaip laikaisi? – žvaliai paklausė."},
+		},
+		{
+			name: "3) Sentence ending with exclamation mark with two dots",
+			args: args{
+				text: "– A tu, žabali, ar nenustosi!.. Savo žmogaus nemato, – girdi jisai pažįstamą balsą.",
+			},
+			want: []string{
+				"– A tu, žabali, ar nenustosi!..",
+				"Savo žmogaus nemato, – girdi jisai pažįstamą balsą.",
+			},
+		},
+		{
+			name: "4) Sentence ending with question mark and two dots",
+			args: args{
+				text: "Manot – neįmanoma?! Pasakyti reikės, tačiau ką aš pasakysiu?.. Ar ji pati nesuvokia, kokia yra juokinga?..",
+			},
+			want: []string{
+				"Manot – neįmanoma?!",
+				"Pasakyti reikės, tačiau ką aš pasakysiu?..",
+				"Ar ji pati nesuvokia, kokia yra juokinga?..",
+			},
+		},
+		{
+			name: "5) Sentence ending with ellipsis",
+			args: args{
+				text: "Juk jisai nekaltas… Brisius nori pasigerinti, suvizginti uodegą, bet iš baimės tupiasi ant paskutinių kojų, ir per jo snukį rieda gailios karčios ašaros.",
+			},
+			want: []string{
+				"Juk jisai nekaltas…",
+				"Brisius nori pasigerinti, suvizginti uodegą, bet iš baimės tupiasi ant paskutinių kojų, ir per jo snukį rieda gailios karčios ašaros.",
+			},
+		},
+		{
+			name: "6) Upper case after abbreviations",
+			args: args{
+				text: "Pasak prof. Petrausko, šilauoges valgyti labai sveika.",
+			},
+			want: []string{"Pasak prof. Petrausko, šilauoges valgyti labai sveika."},
+		},
+		{
+			name: "7) Direct speech in double quotes",
+			args: args{text: "„Argi mudu čia ne vienu du pasaulyje?“ – mąstė jis, drąsindamas pats save."},
+			want: []string{"„Argi mudu čia ne vienu du pasaulyje?“ – mąstė jis, drąsindamas pats save."},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sg := sentencizer.NewSegmenter("lt")
+			got := sg.Segment(tt.args.text)
+			for i, v := range got {
+				if i >= len(tt.want) {
+					break
+				}
+				if v != tt.want[i] {
+					t.Errorf("Segmenter.Segment() = %#v, want %#v", v, tt.want[i])
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("Segmenter.Segment() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for Lithuanian language.

Abbreviations are based on VLKK article[1]. Includes punctuation support for direct speech, Lithuanian double quotes and end of sentence punctuation with ellipsis and question/exclamation mark followed by two periods.

[1]: https://www.vlkk.lt/aktualiausios-temos/rasyba/sutrumpinimai